### PR TITLE
Mudlet Autoprobe

### DIFF
--- a/src/main/mudlet/MerchantLord.xml
+++ b/src/main/mudlet/MerchantLord.xml
@@ -229,8 +229,13 @@ MerchantLord.database = db:create("merchantlord", {
     price = 0,
     last_seen = db:Timestamp("CURRENT_TIMESTAMP"),
     _index = { {"short_description", "shop"} }
-  }, config = {
-    autoProbe = false
+  },
+  config = {
+    config = 1,
+    autoProbe = false,
+    _index = {"config"},
+    _unique = {"config"},
+    _violations = "REPLACE"
   }
 })
 
@@ -309,6 +314,7 @@ end
 --Creates and stores the merchantlord config
 function MerchantLord.addConfig()
     local config = {
+      config = 1,
       autoProbe = false
     }
     db:add(MerchantLord.database.config,config)
@@ -443,7 +449,6 @@ function MerchantLord.updateItemDesigner(currentItem,designer)
   local item = MerchantLord.queryItemByShortDescription(currentItem)
   item.designer = designer
   db:update(MerchantLord.database.items,item)
-  echo("DESIGNER")
 end
 
 --Item Database order by clause for short name and short description
@@ -637,7 +642,7 @@ function MerchantLord.getItemLocationDataSortedByPriceAndArea(priceTable,shopTab
 end
 
 --Gets the next unprobed item for a shop
-function getNextUnprobedItem()
+function MerchantLord.getNextUnprobedItem()
   local shop = MerchantLord.getShopInformationFromGMCP()
   
   if shop == nil then
@@ -663,8 +668,13 @@ end
 
 --Clears the current item for data harvest
 function MerchantLord.clearCurrentItem()
+  if MerchantLord.currentItem == nil then
+    return
+  end
+
   if MerchantLord.currentItemClearCount == nil then
     MerchantLord.currentItemClearCount = 1
+    tempTimer(1, [[MerchantLord.probeNextItem(true)]])
   else
     MerchantLord.currentItemClearCount = nil
     MerchantLord.currentItem = nil
@@ -821,12 +831,15 @@ function MerchantLord.findItemByString(searchString)
 end
 
 --Probes the next unprobed item in a shop
-function MerchantLord.probeNextItem()
+function MerchantLord.probeNextItem(silent)
   echo("\nFinding item to probe in current location")
   local itemData = MerchantLord.getNextUnprobedItem()
   
   if itemData == nil then
-    echo("\nNo unprobed items found!\n")
+    if silent ~= nil then
+      echo("\nNo unprobed items found!\n")
+    end
+    return
   end
   
   MerchantLord.setCurrentItem(itemData.item.short_description)

--- a/src/main/mudlet/MerchantLord.xml
+++ b/src/main/mudlet/MerchantLord.xml
@@ -165,7 +165,7 @@
 			</Alias>
 			<Alias isActive="yes" isFolder="no">
 				<name>Probe Next Item</name>
-				<script>MerchantLord.probeNextItem()</script>
+				<script>MerchantLord.probeNextItem(nil)</script>
 				<command></command>
 				<packageName></packageName>
 				<regex>^ml probe$</regex>
@@ -229,6 +229,8 @@ MerchantLord.database = db:create("merchantlord", {
     price = 0,
     last_seen = db:Timestamp("CURRENT_TIMESTAMP"),
     _index = { {"short_description", "shop"} }
+  }, config = {
+    autoProbe = false
   }
 })
 
@@ -285,6 +287,41 @@ end
 -----------------
 --Database Access
 -----------------
+
+--Retrieves config to load into memory
+function MerchantLord.loadConfig()
+  local config = MerchantLord.config
+  
+  if config == nil then
+    config = db:fetch(MerchantLord.database.config)[1]
+
+    if config == nil then
+      MerchantLord.addConfig()
+      --this is fine as it will resolve and pass this check after addConfig
+      config = MerchantLord.loadConfig()
+    end
+    MerchantLord.config = config
+  end
+
+  return config
+end
+
+--Creates and stores the merchantlord config
+function MerchantLord.addConfig()
+    local config = {
+      autoProbe = false
+    }
+    db:add(MerchantLord.database.config,config)
+end
+
+--Stores the config in memory to the database
+function MerchantLord.updateConfig()
+    local config = MerchantLord.config
+    local databaseConfig = MerchantLord.loadConfig()
+    
+    databaseConfig.autoProbe = config.autoProbe
+    db:update(MerchantLord.database.config,databaseConfig)
+end
 
 --Retrieves the shops table
 function MerchantLord.queryAllShops()
@@ -493,6 +530,9 @@ end
 --Data Utilities
 ----------------
 
+--Gets the config from local memory. Loads it if it is not in memory
+
+
 --Gets shop information from GMCP and calls database storage
 function MerchantLord.getShopInformationFromGMCP()
   local shop = {
@@ -596,6 +636,31 @@ function MerchantLord.getItemLocationDataSortedByPriceAndArea(priceTable,shopTab
   return priceAreaTable
 end
 
+--Gets the next unprobed item for a shop
+function getNextUnprobedItem()
+  local shop = MerchantLord.getShopInformationFromGMCP()
+  
+  if shop == nil then
+    return nil
+  end
+  
+  local itemLocations = MerchantLord.queryItemLocationsByShop(shop)
+  local itemLocationTable = MerchantLord.formatItemLocationDataToShortDescriptions(itemLocations)
+  local items = MerchantLord.queryUndescribedItemsByShortDescription(itemLocationTable.shortDescriptions)
+
+  for itemIndex,item in pairs(items) do
+    if item.description == "" then
+      local itemLocation = itemLocationTable.itemLocations[item.short_description]
+      return {
+        item = item,
+        itemLocation = itemLocation
+      }
+    end
+  end
+  
+  return nil
+end
+
 --Clears the current item for data harvest
 function MerchantLord.clearCurrentItem()
   if MerchantLord.currentItemClearCount == nil then
@@ -671,11 +736,13 @@ end
 
 --Displays all relevant information about a specific item
 function MerchantLord.recallItemByShort(shortDescription)
-  echo("\nFinding all information about: " .. shortDescription)
-  local item = MerchantLord.queryItemByShortDescription(shortDescription)
+  local sanitizedSortDescription = MerchantLord.trimString(shortDescription)
+  echo("\nFinding all information about: " .. sanitizedSortDescription)
+  local item = MerchantLord.queryItemByShortDescription(sanitizedSortDescription)
 
   if item == nil then
-    echo("\nCould not find information about: " .. shortDescription)
+    echo("\nCould not find information about: " .. sanitizedSortDescription)
+    return
   end
 
   local displayString = "\nDescription: "
@@ -756,26 +823,14 @@ end
 --Probes the next unprobed item in a shop
 function MerchantLord.probeNextItem()
   echo("\nFinding item to probe in current location")
-  local shop = MerchantLord.getShopInformationFromGMCP()
+  local itemData = MerchantLord.getNextUnprobedItem()
   
-  if shop == nil then
-    echo("\nYou are not in a shop!\n")
-    return
+  if itemData == nil then
+    echo("\nNo unprobed items found!\n")
   end
   
-  local itemLocations = MerchantLord.queryItemLocationsByShop(shop)
-  local itemLocationTable = MerchantLord.formatItemLocationDataToShortDescriptions(itemLocations)
-  local items = MerchantLord.queryUndescribedItemsByShortDescription(itemLocationTable.shortDescriptions)
-
-  for itemIndex,item in pairs(items) do
-    if item.description == "" then
-      local itemLocation = itemLocationTable.itemLocations[item.short_description]
-      MerchantLord.setCurrentItem(item.short_description)
-      send("probe " .. itemLocation.item_name)
-      return
-    end
-  end
-  echo("\nNo unprobed items found!\n")
+  MerchantLord.setCurrentItem(itemData.item.short_description)
+  send("probe " .. itemData.itemLocation.item_name)
 end
 
 --Displays item location and price information for a short description equal to searchString

--- a/src/main/mudlet/MerchantLord.xml
+++ b/src/main/mudlet/MerchantLord.xml
@@ -177,6 +177,13 @@
 				<packageName></packageName>
 				<regex>^ml recall (.+)$</regex>
 			</Alias>
+			<Alias isActive="yes" isFolder="no">
+				<name>Settings</name>
+				<script>MerchantLord.processSettingsCommand(matches[2])</script>
+				<command></command>
+				<packageName></packageName>
+				<regex>^ml settings (.+)$</regex>
+			</Alias>
 		</AliasGroup>
 	</AliasPackage>
 	<ActionPackage />
@@ -230,11 +237,11 @@ MerchantLord.database = db:create("merchantlord", {
     last_seen = db:Timestamp("CURRENT_TIMESTAMP"),
     _index = { {"short_description", "shop"} }
   },
-  config = {
-    config = 1,
-    autoProbe = false,
-    _index = {"config"},
-    _unique = {"config"},
+  settings = {
+    name = "default",
+    auto_probe = "off",
+    _index = {"name"},
+    _unique = {"name"},
     _violations = "REPLACE"
   }
 })
@@ -289,44 +296,43 @@ function MerchantLord.makeStringFromTable(stringTable)
   return returnString
 end
 
+--Taken from http://lua-users.org/wiki/SplitJoin
+--Splits a string into a table
+function MerchantLord.splitString(stringToSplit,separator)
+   local separator = separator or " "
+   local fields = {}
+   local pattern = string.format("([^%s]+)", separator)
+   string.gsub(stringToSplit,pattern, function(c) fields[#fields+1] = c end)
+   return fields
+end
+
 -----------------
 --Database Access
 -----------------
 
---Retrieves config to load into memory
-function MerchantLord.loadConfig()
-  local config = MerchantLord.config
-  
-  if config == nil then
-    config = db:fetch(MerchantLord.database.config)[1]
+--Gets the settings from local memory. Loads it if it is not in memory
+function MerchantLord.loadSettings()
+  local settings = db:fetch(MerchantLord.database.settings)[1]
 
-    if config == nil then
-      MerchantLord.addConfig()
-      --this is fine as it will resolve and pass this check after addConfig
-      config = MerchantLord.loadConfig()
-    end
-    MerchantLord.config = config
-  end
-
-  return config
+  return settings
 end
 
---Creates and stores the merchantlord config
-function MerchantLord.addConfig()
-    local config = {
-      config = 1,
-      autoProbe = false
+--Creates and stores the merchantlord settings
+function MerchantLord.addSettings()
+    local settings = {
+      name = "default",
+      auto_probe = "off"
     }
-    db:add(MerchantLord.database.config,config)
+    db:add(MerchantLord.database.settings,settings)
 end
 
---Stores the config in memory to the database
-function MerchantLord.updateConfig()
-    local config = MerchantLord.config
-    local databaseConfig = MerchantLord.loadConfig()
+--Stores the settings in memory to the database
+function MerchantLord.updateSettings()
+    local settings = MerchantLord.settings
+    local databaseSettings = MerchantLord.loadSettings()
     
-    databaseConfig.autoProbe = config.autoProbe
-    db:update(MerchantLord.database.config,databaseConfig)
+    databaseSettings.auto_probe = settings.auto_probe
+    db:update(MerchantLord.database.settings,databaseSettings)
 end
 
 --Retrieves the shops table
@@ -531,12 +537,49 @@ function MerchantLord.upsertItemLocationData(itemLocationData)
   end
 end
 
-----------------
---Data Utilities
-----------------
+----------------------------
+--Data Utilities and Helpers
+----------------------------
 
---Gets the config from local memory. Loads it if it is not in memory
+--Gets the settings from local memory. Loads it if it is not in memory
+function MerchantLord.getSettings()
+  local settings = MerchantLord.settings
+  
+  if settings == nil then
+    settings = MerchantLord.loadSettings()
 
+    if settings == nil then
+      MerchantLord.addSettings()
+      --this is fine as it will resolve and pass this check after addSettings
+      settings = MerchantLord.loadSettings()
+    end
+    MerchantLord.settings = settings
+  end
+
+  return settings
+end
+
+--Sets autoprobe for merchantlord
+function MerchantLord.setAutoProbe(status)
+  MerchantLord.getSettings()
+  
+  local validStatus = string.lower(status)
+
+  if validStatus == "on" then
+    MerchantLord.settings.auto_probe = "on"
+  elseif validStatus == "off" then
+    MerchantLord.settings.auto_probe = "off"
+  end
+  
+  echo("\nMerchant Lord Autoprobe: " .. MerchantLord.getAutoProbe() .. "\n")
+  MerchantLord.updateSettings()
+end
+
+--Gets the autoprobe setting safely
+function MerchantLord.getAutoProbe()
+  MerchantLord.getSettings()
+  return MerchantLord.settings.auto_probe
+end
 
 --Gets shop information from GMCP and calls database storage
 function MerchantLord.getShopInformationFromGMCP()
@@ -674,7 +717,9 @@ function MerchantLord.clearCurrentItem()
 
   if MerchantLord.currentItemClearCount == nil then
     MerchantLord.currentItemClearCount = 1
-    tempTimer(1, [[MerchantLord.probeNextItem(true)]])
+    if MerchantLord.getAutoProbe() == "on" then
+      tempTimer(1, [[MerchantLord.probeNextItem(true)]])
+    end
   else
     MerchantLord.currentItemClearCount = nil
     MerchantLord.currentItem = nil
@@ -690,6 +735,19 @@ end
 -----------------
 --Exposed Methods
 -----------------
+
+--Entry point for settings command
+function MerchantLord.processSettingsCommand(settingsArguments)
+  local argumentsTable = MerchantLord.splitString(settingsArguments," ")
+  local settingsCommand = string.lower(argumentsTable[1])
+
+  --TODO: Make this a table to be more elegant.
+  if settingsCommand == "autoprobe" then
+    MerchantLord.setAutoProbe(argumentsTable[2])
+  else
+    echo("\nDid not recognize the Merchant Lord setting: " .. argumentsTable .. ".\n")    
+  end
+end
 
 --Formats shop information from GMCP and calls database storage
 function MerchantLord.parseShopInformationFromGMCP()


### PR DESCRIPTION
# Changes #
* Added the command `ml settings autoprobe <on|off>` to toggle autoprobe settings. The default is off.
* `ml probe` will automatically probe items once every second until it has probed every item detected with wares if autoprobe is on.

# Issues Closed #
#19 